### PR TITLE
Make unix_compile.config optional

### DIFF
--- a/yacht.sh
+++ b/yacht.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 compile() {
-  source unix_compile.config
+  if [ -f unix_compile.config ]; then
+    source unix_compile.config
+  fi
   build_type=$1 # Debug or Release
   target_name=$2
 


### PR DESCRIPTION
If you run `./yacht.sh clean` without that file, it complains it doesn't exist