### PR TITLE
Disable project checks in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,6 @@
 ---
-Checks: '*,-modernize-use-trailing-return-type,-llvm-header-guard,-google-build-using-namespace,-clang-analyzer-alpha.clone.CloneChecker,-google-runtime-int,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-clang-analyzer-alpha.deadcode.UnreachableCode,-misc-use-after-move,-cppcoreguidelines-pro-type-vararg,-modernize-use-emplace,-cert-err60-cpp,-llvmlibc-*'
+# Enable all checks by default, and remove all project specific ones
+# You might want to add/remove other checks depending on your project
+# Also disables some stylistic checks by default to make things simpler
+Checks: '*,-llvm*,-fuchsia*,-google*,-abseil*,-zircon,-modernize-use-trailing-return-type'
 ...


### PR DESCRIPTION
Also changed some of the removed warnings to make the template more generic.